### PR TITLE
Python support update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
-env:
-    - TOXENV=py36
-    - TOXENV=py37
-    - TOXENV=py38
-    - TOXENV=pep8
-    - TOXENV=coverage
 matrix:
     include:
         - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,27 @@
 language: python
 
-python: 3.5
+python:
+    - "3.6"
+    - "3.7"
+    - "3.8"
 env:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
-    - TOXENV=pypy
-    - TOXENV=pypy3
+    - TOXENV=py36
+    - TOXENV=py37
+    - TOXENV=py38
     - TOXENV=pep8
+    - TOXENV=coverage
+matrix:
+    include:
+        - python: "3.6"
+          env: TOXENV=py36
+        - python: "3.7"
+          env: TOXENV=py37
+        - python: "3.8"
+          env: TOXENV=py38
+        - python: "3.8"
+          env: TOXENV=pep8
+        - python: "3.8"
+          env: TOXENV=coverage
 install:
     - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
+python: 3.8
+
+cache: pip
+
 matrix:
     include:
         - python: "3.6"
@@ -16,6 +16,8 @@ matrix:
           env: TOXENV=pep8
         - python: "3.8"
           env: TOXENV=coverage
+before_install:
+    - pip install --upgrade pip setuptools
 install:
     - pip install tox
 script:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ CHANGES
 0.11 (unreleased)
 =================
 
-- Nothing changed yet.
+- Drop support for Python below 3.6
 
 
 0.10 (2016-10-04)

--- a/more/static/__init__.py
+++ b/more/static/__init__.py
@@ -1,1 +1,1 @@
-from .core import StaticApp  # flake8: noqa
+from .core import StaticApp  # noqa

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,9 @@ setup(
     zip_safe=False,
     classifiers=[
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     install_requires=[
         'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         test=[
             'pytest-cov',
             'WebTest >= 2.0.14'
+            'tox'
         ],
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,21 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pep8
+envlist = py36,py37,py38,pypy3,pep8,coverage
 
 [testenv]
 deps = -e{toxinidir}[test]
 usedevelop = True
 commands = pytest {posargs}
 
-[testenv:py37]
-commands = pytest --cov more.static --cov-report term-missing --cov-fail-under=100 {posargs}
-
 [testenv:pep8]
-basepython = python3.7
-deps = {[testenv]deps}
-       flake8
+basepython = python3.8
+deps = flake8
+       pep8
 commands = flake8 more setup.py
+
+[testenv:coverage]
+basepython = python3.8
+deps = {[testenv]deps}
+commands = pytest --cov more.static --cov-report term-missing --cov-fail-under=100 {posargs}
 
 [pytest]
 testpaths = more/static

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,pypy3,pep8
+envlist = py36,py37,py38,pypy3,pep8
 
 [testenv]
 deps = -e{toxinidir}[test]
-commands = py.test {posargs}
+usedevelop = True
+commands = pytest {posargs}
 
-[testenv:py35]
-commands = py.test --cov more.static --cov-report term-missing --cov-fail-under=100 {posargs}
+[testenv:py37]
+commands = pytest --cov more.static --cov-report term-missing --cov-fail-under=100 {posargs}
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3.7
 deps = {[testenv]deps}
        flake8
 commands = flake8 more setup.py


### PR DESCRIPTION
This merge request updates the minimal Python version to 3.7 and adds 3.8.

It also adds the tools required to run the tests to list of dependencies.

Fixes #13 