### PR TITLE
Add black for Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black

--- a/more/__init__.py
+++ b/more/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/more/static/core.py
+++ b/more/static/core.py
@@ -8,7 +8,6 @@ from morepath.app import App
 
 
 class IncludeRequest(Request):
-
     def include(self, path_or_resource, renderer=None):
         include = self.app.bower_components.includer(self.environ)
         include(path_or_resource, renderer)
@@ -18,15 +17,14 @@ class StaticComponentsDirective(dectate.Action):
     app_class_arg = True
 
     def __init__(self):
-        """Register a function that returns static components.
-        """
+        """Register a function that returns static components."""
 
     def identifier(self, app_class):
         # only one static components per app
         return ()
 
     def perform(self, obj, app_class):
-        app_class.get_static_components = reg.methodify(obj, selfname='app')
+        app_class.get_static_components = reg.methodify(obj, selfname="app")
 
 
 class StaticApp(App):

--- a/more/static/tests/test_static.py
+++ b/more/static/tests/test_static.py
@@ -7,109 +7,114 @@ def test_static():
     class App(StaticApp):
         pass
 
-    @App.path(path='/')
+    @App.path(path="/")
     class Root(object):
         pass
 
     @App.html(model=Root)
     def default(self, request):
-        request.include('jquery')
-        return '<html><head></head><body></body></html>'
+        request.include("jquery")
+        return "<html><head></head><body></body></html>"
 
     @App.static_components()
     def get_static_includer():
         bower = bowerstatic.Bower()
         components = bower.components(
-            'myapp', bowerstatic.module_relative_path('bower_components'))
+            "myapp", bowerstatic.module_relative_path("bower_components")
+        )
 
         return components
 
     c = Client(App())
-    response = c.get('/')
+    response = c.get("/")
 
     assert response.body == (
-        b'<html><head>'
+        b"<html><head>"
         b'<script type="text/javascript" '
         b'src="/bowerstatic/myapp/jquery/2.1.1/dist/jquery.js"></script>'
-        b'</head><body></body></html>')
+        b"</head><body></body></html>"
+    )
 
 
 def test_component_url():
     class App(StaticApp):
         pass
 
-    @App.path(path='/')
+    @App.path(path="/")
     class Root(object):
         pass
 
     @App.html(model=Root)
     def default(self, request):
-        return request.app.bower_components.get_component('jquery').url()
+        return request.app.bower_components.get_component("jquery").url()
 
     @App.static_components()
     def get_static_includer():
         bower = bowerstatic.Bower()
         components = bower.components(
-            'myapp', bowerstatic.module_relative_path('bower_components'))
+            "myapp", bowerstatic.module_relative_path("bower_components")
+        )
 
         return components
 
     c = Client(App())
-    response = c.get('/')
+    response = c.get("/")
 
     assert response.body == b"/bowerstatic/myapp/jquery/2.1.1/"
 
     # make sure the response can acutally get loaded
-    response = c.get('/bowerstatic/myapp/jquery/2.1.1/dist/jquery.js')
+    response = c.get("/bowerstatic/myapp/jquery/2.1.1/dist/jquery.js")
     assert response.body == b"/* this is a fake jquery.js */\n"
 
     # if it exists
-    c.get('/bowerstatic/myapp/jquery/2.1.1/dist/inexistant.js', status=404)
+    c.get("/bowerstatic/myapp/jquery/2.1.1/dist/inexistant.js", status=404)
 
 
 def test_components_unused():
     class App(StaticApp):
         pass
 
-    @App.path(path='/')
+    @App.path(path="/")
     class Root(object):
         pass
 
     @App.html(model=Root)
     def default(self, request):
-        return '<html><head></head><body></body></html>'
+        return "<html><head></head><body></body></html>"
 
     c = Client(App())
-    response = c.get('/')
+    response = c.get("/")
 
-    assert response.body == b'<html><head></head><body></body></html>'
+    assert response.body == b"<html><head></head><body></body></html>"
 
 
 def test_custom_renderer():
     class App(StaticApp):
         pass
 
-    @App.path(path='/')
+    @App.path(path="/")
     class Root(object):
         pass
 
     @App.html(model=Root)
     def default(self, request):
-        request.include('jquery', '<foo>{url}</foo>')
-        return '<html><head></head><body></body></html>'
+        request.include("jquery", "<foo>{url}</foo>")
+        return "<html><head></head><body></body></html>"
 
     @App.static_components()
     def get_static_includer():
         bower = bowerstatic.Bower()
         components = bower.components(
-            'myapp', bowerstatic.module_relative_path('bower_components'))
+            "myapp", bowerstatic.module_relative_path("bower_components")
+        )
 
         return components
 
     c = Client(App())
-    response = c.get('/')
+    response = c.get("/")
 
     assert response.body == (
-        b'<html><head>'
-        b'<foo>/bowerstatic/myapp/jquery/2.1.1/dist/jquery.js</foo>'
-        b'</head><body></body></html>')
+        b"<html><head>"
+        b"<foo>/bowerstatic/myapp/jquery/2.1.1/dist/jquery.js</foo>"
+        b"</head><body></body></html>"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 80
-target-version = ['py34', 'py35', 'py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 80
+target-version = ['py34', 'py35', 'py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.git
+    | \.tox
+    | env
+    | build
+    | dist
+    | bootstrap.py
+  )/
+)
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@ ignore = E203, E731, W503
 max-line-length = 88
 exclude = boostrap.py
 
-[black]
-exclude = bootstrap.py
-
 [tool:pytest]
 testpaths = more/static
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[flake8]
+show-source = True
+ignore = E203, E731, W503
+max-line-length = 88
+exclude = boostrap.py
+
+[black]
+exclude = bootstrap.py
+
+[tool:pytest]
+testpaths = more/static
+
+[coverage:run]
+omit = more/static/tests/*
+source = more/static
+
+[coverage:report]
+show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,24 @@
 import io
 from setuptools import setup, find_packages
 
-long_description = '\n'.join((
-    io.open('README.rst', encoding='utf-8').read(),
-    io.open('CHANGES.txt', encoding='utf-8').read()
-))
+long_description = "\n".join(
+    (
+        io.open("README.rst", encoding="utf-8").read(),
+        io.open("CHANGES.txt", encoding="utf-8").read(),
+    )
+)
 
 setup(
-    name='more.static',
-    version='0.11.dev0',
+    name="more.static",
+    version="0.11.dev0",
     description="BowerStatic integration for Morepath",
     long_description=long_description,
     author="Martijn Faassen",
     author_email="faassen@startifact.com",
-    keywords='morepath bowerstatic bower',
+    keywords="morepath bowerstatic bower",
     license="BSD",
     url="https://github.com/morepath/more.static",
-    namespace_packages=['more'],
+    namespace_packages=["more"],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
@@ -29,12 +31,16 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     install_requires=[
-        'setuptools',
-        'morepath >= 0.16',
-        'bowerstatic >= 0.8',
+        "setuptools",
+        "morepath >= 0.16",
+        "bowerstatic >= 0.8",
     ],
     extras_require=dict(
-        test=["pytest >= 2.9.0", "WebTest >= 2.0.14", "pytest-remove-stale-bytecode"],
+        test=[
+            "pytest >= 2.9.0",
+            "WebTest >= 2.0.14",
+            "pytest-remove-stale-bytecode",
+        ],
         pep8=["flake8", "black"],
         coverage=["pytest-cov"],
     ),

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,8 @@ setup(
         'bowerstatic >= 0.8',
     ],
     extras_require=dict(
-        test=[
-            'pytest-cov',
-            'WebTest >= 2.0.14'
-            'tox'
-        ],
+        test=["pytest >= 2.9.0", "WebTest >= 2.0.14", "pytest-remove-stale-bytecode"],
+        pep8=["flake8", "black"],
+        coverage=["pytest-cov"],
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,25 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pep8,coverage
+envlist = py36, py37, py38, pypy3, coverage, pep8
+skipsdist = True
+skip_missing_interpreters = True
 
 [testenv]
-deps = -e{toxinidir}[test]
 usedevelop = True
+extras = test
+
 commands = pytest {posargs}
 
 [testenv:pep8]
 basepython = python3.8
-deps = flake8
-       pep8
-commands = flake8 more setup.py
+extras = pep8
+
+commands = flake8 more/ setup.py
+           black --check more/ setup.py
 
 [testenv:coverage]
 basepython = python3.8
-deps = {[testenv]deps}
-commands = pytest --cov more.static --cov-report term-missing --cov-fail-under=100 {posargs}
+extras = test
+         coverage
 
-[pytest]
-testpaths = more/static
+commands = pytest --cov more/static --cov-fail-under=100 {posargs}
+


### PR DESCRIPTION
This merge requests adds black for Python to the tools used when running the pep8 compliance tests.

It follows the morepath/reg project so that they now share their test infrastructure more.

The code has been then passed through black except for bootstrap.py that is an external script.